### PR TITLE
enhancement(tags): support unstable releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The script cuts a major, minor or patch release, generates/updates the changelog
 npm script hook, updates the project version, runs the post-versioning npm script hook, commits the changes to master
 with the message `"Release version <version>."`, and then commits a new tag with the same message.
 
-Include the `--dryrun` flag to stop the script after the post-versioning npm script hook, so no changes are
+Include the `--dryrun` flag to stop the script after the versioning is completed, so no changes are
 committed to master. Include the `--skip-checkout` flag to commit the changes to current branch.
 
 ```json
@@ -59,7 +59,7 @@ hook, updates the project, lerna config and package versions, writes the list of
 `.lerna.updated.json`, runs the post-versioning npm script hook, commits the changes to master with the message
 `"Release version <version>."`, and then commits a new tag with the same message.
 
-Include the `--dryrun` flag to stop the script after the post-versioning npm script hook, so no changes are
+Include the `--dryrun` flag to stop the script after the versioning is completed, so no changes are
 committed to master. Include the `--force` flag to force update all packages to the new version. Include the
 `--skip-checkout` flag to commit the changes to current branch.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm script hook, updates the project version, runs the post-versioning npm scrip
 with the message `"Release version <version>."`, and then commits a new tag with the same message.
 
 Include the `--dryrun` flag to stop the script after the post-versioning npm script hook, so no changes are
-committed to master.
+committed to master. Include the `--skip-checkout` flag to commit the changes to current branch.
 
 ```json
 "scripts": {
@@ -47,7 +47,8 @@ committed to master.
 ```bash
 yarn run cutoff
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta>]
+  [--tag <alfa | beta | unstable>]
+  [--skip-checkout]
   [--dryrun]
 ```
 
@@ -59,7 +60,8 @@ hook, updates the project, lerna config and package versions, writes the list of
 `"Release version <version>."`, and then commits a new tag with the same message.
 
 Include the `--dryrun` flag to stop the script after the post-versioning npm script hook, so no changes are
-committed to master. Include the `--force` flag to force update all packages to the new version.
+committed to master. Include the `--force` flag to force update all packages to the new version. Include the
+`--skip-checkout` flag to commit the changes to current branch.
 
 ```json
 "scripts": {
@@ -70,7 +72,8 @@ committed to master. Include the `--force` flag to force update all packages to 
 ```bash
 yarn run cutoff-lerna
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta>]
+  [--tag <alfa | beta | unstable>]
+  [--skip-checkout]
   [--dryrun]
   [--force]
 ```

--- a/src/cut-release/index.test.ts
+++ b/src/cut-release/index.test.ts
@@ -100,7 +100,7 @@ describe("the cutRelease function", () => {
 
   describe("when skip-checkout is passed into the function", () => {
     beforeAll(() => {
-      (yargs.parse as jest.Mock).mockReturnValue({ "skip-checkout": true, "type": "patch" });
+      (yargs.parse as jest.Mock).mockReturnValue({ skipCheckout: true, type: "patch" });
       (getNewVersion as jest.Mock).mockReturnValue("0.0.2");
       (checkoutMaster as jest.Mock).mockClear();
       cutRelease();

--- a/src/cut-release/index.test.ts
+++ b/src/cut-release/index.test.ts
@@ -97,4 +97,17 @@ describe("the cutRelease function", () => {
       expect(addCommitPush).not.toHaveBeenCalled();
     });
   });
+
+  describe("when skip-checkout is passed into the function", () => {
+    beforeAll(() => {
+      (yargs.parse as jest.Mock).mockReturnValue({ "skip-checkout": true, "type": "patch" });
+      (getNewVersion as jest.Mock).mockReturnValue("0.0.2");
+      (checkoutMaster as jest.Mock).mockClear();
+      cutRelease();
+    });
+
+    it("then the function should not call checkoutMaster", () => {
+      expect(checkoutMaster).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -9,8 +9,13 @@ import isValidReleaseType from "../helpers/is-valid-release-type";
 import { PackageConfig, ReleaseTag } from "../types";
 
 export default function cutRelease(): void {
-  const argv = yargs.boolean("dryrun").parse();
+  const argv = yargs
+    .boolean("dryrun")
+    .boolean("skip-checkout")
+    .parse();
+
   const dryrun: boolean = argv.dryrun;
+  const skipCheckout: boolean = argv["skip-checkout"];
   const type: ReleaseType = argv.type;
   const tag: ReleaseTag | undefined = argv.tag;
 
@@ -26,7 +31,9 @@ export default function cutRelease(): void {
   const newVersion = getNewVersion(version, type, tag);
   if (!newVersion) return;
 
-  checkoutMaster();
+  if (!skipCheckout) {
+    checkoutMaster();
+  }
 
   if (["patch", "minor", "major"].includes(type)) {
     shell.exec(`yarn run changelog --${type}`);

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -15,7 +15,7 @@ export default function cutRelease(): void {
     .parse();
 
   const dryrun: boolean = argv.dryrun;
-  const skipCheckout: boolean = argv["skip-checkout"];
+  const skipCheckout: boolean = argv.skipCheckout;
   const type: ReleaseType = argv.type;
   const tag: ReleaseTag | undefined = argv.tag;
 

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -45,11 +45,11 @@ export default function cutRelease(): void {
 
   shell.exec(`yarn version --new-version ${newVersion} --no-git-tag-version`);
 
-  if (dryrun) return;
-
   if (scripts["cutoff:post-version"]) {
     shell.exec("yarn run cutoff:post-version");
   }
+
+  if (dryrun) return;
 
   addCommitPush(newVersion);
 }

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -45,11 +45,11 @@ export default function cutRelease(): void {
 
   shell.exec(`yarn version --new-version ${newVersion} --no-git-tag-version`);
 
+  if (dryrun) return;
+
   if (scripts["cutoff:post-version"]) {
     shell.exec("yarn run cutoff:post-version");
   }
-
-  if (dryrun) return;
 
   addCommitPush(newVersion);
 }

--- a/src/helpers/get-tag/index.ts
+++ b/src/helpers/get-tag/index.ts
@@ -1,4 +1,5 @@
 export default function getTag(version: string): string | void {
   if (/alfa/.test(version)) return "alfa";
   if (/beta/.test(version)) return "beta";
+  if (/unstable/.test(version)) return "unstable";
 }

--- a/src/lerna/cut-release/index.test.ts
+++ b/src/lerna/cut-release/index.test.ts
@@ -141,7 +141,7 @@ describe("the cutLernaRelease function", () => {
 
   describe("when skip-checkout is passed into the function", () => {
     beforeAll(() => {
-      (yargs.parse as jest.Mock).mockReturnValue({ "skip-checkout": true, "type": "patch" });
+      (yargs.parse as jest.Mock).mockReturnValue({ skipCheckout: true, type: "patch" });
       (getNewVersion as jest.Mock).mockReturnValue("0.0.2");
       (checkoutMaster as jest.Mock).mockClear();
       cutLernaRelease();

--- a/src/lerna/cut-release/index.test.ts
+++ b/src/lerna/cut-release/index.test.ts
@@ -138,4 +138,17 @@ describe("the cutLernaRelease function", () => {
       expect(addCommitPush).not.toHaveBeenCalled();
     });
   });
+
+  describe("when skip-checkout is passed into the function", () => {
+    beforeAll(() => {
+      (yargs.parse as jest.Mock).mockReturnValue({ "skip-checkout": true, "type": "patch" });
+      (getNewVersion as jest.Mock).mockReturnValue("0.0.2");
+      (checkoutMaster as jest.Mock).mockClear();
+      cutLernaRelease();
+    });
+
+    it("then the function should not call checkoutMaster", () => {
+      expect(checkoutMaster).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/lerna/cut-release/index.ts
+++ b/src/lerna/cut-release/index.ts
@@ -20,7 +20,7 @@ export default function cutLernaRelease(): void {
 
   const dryrun: boolean = argv.dryrun;
   const force: boolean = argv.force;
-  const skipCheckout: boolean = argv["skip-checkout"];
+  const skipCheckout: boolean = argv.skipCheckout;
   const tag: ReleaseTag | undefined = argv.tag;
   const type: ReleaseType = argv.type;
 

--- a/src/lerna/cut-release/index.ts
+++ b/src/lerna/cut-release/index.ts
@@ -62,11 +62,11 @@ export default function cutLernaRelease(): void {
     shell.exec(`yarn version --new-version ${newVersion} --no-git-tag-version`);
   }
 
-  if (dryrun) return;
-
   if (scripts["cutoff:post-version"]) {
     shell.exec("yarn run cutoff:post-version");
   }
+
+  if (dryrun) return;
 
   addCommitPush(newVersion);
 }

--- a/src/lerna/cut-release/index.ts
+++ b/src/lerna/cut-release/index.ts
@@ -62,11 +62,11 @@ export default function cutLernaRelease(): void {
     shell.exec(`yarn version --new-version ${newVersion} --no-git-tag-version`);
   }
 
+  if (dryrun) return;
+
   if (scripts["cutoff:post-version"]) {
     shell.exec("yarn run cutoff:post-version");
   }
-
-  if (dryrun) return;
 
   addCommitPush(newVersion);
 }

--- a/src/lerna/cut-release/index.ts
+++ b/src/lerna/cut-release/index.ts
@@ -15,10 +15,12 @@ export default function cutLernaRelease(): void {
   const argv = yargs
     .boolean("force")
     .boolean("dryrun")
+    .boolean("skip-checkout")
     .parse();
 
   const dryrun: boolean = argv.dryrun;
   const force: boolean = argv.force;
+  const skipCheckout: boolean = argv["skip-checkout"];
   const tag: ReleaseTag | undefined = argv.tag;
   const type: ReleaseType = argv.type;
 
@@ -34,7 +36,9 @@ export default function cutLernaRelease(): void {
   const newVersion = getNewVersion(version, type, tag);
   if (!newVersion) return;
 
-  checkoutMaster();
+  if (!skipCheckout) {
+    checkoutMaster();
+  }
 
   if (["patch", "minor", "major"].includes(type)) {
     shell.exec(`yarn run changelog --${type}`);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,7 +10,7 @@ export interface ObjectMap {
   [key: string]: any;
 }
 
-export type ReleaseTag = "alfa" | "beta";
+export type ReleaseTag = "alfa" | "beta" | "unstable";
 
 export interface PackageConfig {
   name: string;


### PR DESCRIPTION
Added new `unstable` tag value.
Added an extra `--skip-checkout` flag in `cutoff` and `cutoff-lerna` to allow commit the versioning to current branch.