### PR TITLE
feat pre-release identifier suffix for release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ with the message `"Release version <version>."`, and then commits a new tag with
 Include the `--dryrun` flag to stop the script after the versioning is completed, so no changes are
 committed to master. Include the `--skip-checkout` flag to commit the changes to current branch.
 
+If a `preid` is provided it is appended to the release tag.
+
 ```json
 "scripts": {
   "cutoff": "cutoff"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ committed to master. Include the `--skip-checkout` flag to commit the changes to
 ```bash
 yarn run cutoff
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta | unstable>]
+  [--tag <alfa | beta | unstable> [--preid <string>]]
   [--skip-checkout]
   [--dryrun]
 ```
@@ -63,6 +63,8 @@ Include the `--dryrun` flag to stop the script after the versioning is completed
 committed to master. Include the `--force` flag to force update all packages to the new version. Include the
 `--skip-checkout` flag to commit the changes to current branch.
 
+If a `preid` is provided it is appended to the release tag.
+
 ```json
 "scripts": {
   "cutoff-lerna": "cutoff-lerna"
@@ -72,7 +74,7 @@ committed to master. Include the `--force` flag to force update all packages to 
 ```bash
 yarn run cutoff-lerna
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta | unstable>]
+  [--tag <alfa | beta | unstable> [--preid <string>]]
   [--skip-checkout]
   [--dryrun]
   [--force]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ committed to master. Include the `--skip-checkout` flag to commit the changes to
 ```bash
 yarn run cutoff
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta | unstable> [--preid <string>]]
+  [--tag <alpha | beta | unstable> [--preid <string>]]
   [--skip-checkout]
   [--dryrun]
 ```
@@ -74,7 +74,7 @@ If a `preid` is provided it is appended to the release tag.
 ```bash
 yarn run cutoff-lerna
   [--type <major | premajor | minor | preminor | patch | prepatch | prerelease>]
-  [--tag <alfa | beta | unstable> [--preid <string>]]
+  [--tag <alpha | beta | unstable> [--preid <string>]]
   [--skip-checkout]
   [--dryrun]
   [--force]

--- a/src/cut-release/index.test.ts
+++ b/src/cut-release/index.test.ts
@@ -57,7 +57,7 @@ describe("the cutRelease function", () => {
     });
 
     it("then the function should call getNewVersion with the correct version and type", () => {
-      expect(getNewVersion).toHaveBeenCalledWith("0.0.1", "patch", undefined);
+      expect(getNewVersion).toHaveBeenCalledWith("0.0.1", "patch", undefined, undefined);
     });
 
     it("then the function should call checkoutMaster", () => {

--- a/src/cut-release/index.test.ts
+++ b/src/cut-release/index.test.ts
@@ -85,6 +85,22 @@ describe("the cutRelease function", () => {
     });
   });
 
+  describe("when an invalid tag is passed into the function", () => {
+    beforeAll(() => {
+      (yargs.parse as jest.Mock).mockReturnValue({ type: "prerelease", tag: "invalid" });
+      cutRelease();
+    });
+
+    it("then the function should echo the correct message", () => {
+      const message = "cutoff expected tag to be a valid release tag.";
+      expect(shell.echo).toBeCalledWith(message);
+    });
+
+    it("then the function should exit with the correct code", () => {
+      expect(shell.exit).toBeCalledWith(1);
+    });
+  });
+
   describe("when dryrun is passed into the function", () => {
     beforeAll(() => {
       (yargs.parse as jest.Mock).mockReturnValue({ dryrun: true, type: "patch" });

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import addCommitPush from "../helpers/add-commit-push";
 import checkoutMaster from "../helpers/checkout-master";
 import getNewVersion from "../helpers/get-new-version";
+import isValidReleaseTag from "../helpers/is-valid-release-tag";
 import isValidReleaseType from "../helpers/is-valid-release-type";
 import { PackageConfig, PreReleaseId, ReleaseTag } from "../types";
 
@@ -22,6 +23,12 @@ export default function cutRelease(): void {
 
   if (!isValidReleaseType(type)) {
     shell.echo("cutoff expected type to be a valid release type.");
+    shell.exit(1);
+    return;
+  }
+
+  if (tag && !isValidReleaseTag(tag)) {
+    shell.echo("cutoff expected tag to be a valid release tag.");
     shell.exit(1);
     return;
   }

--- a/src/cut-release/index.ts
+++ b/src/cut-release/index.ts
@@ -6,7 +6,7 @@ import addCommitPush from "../helpers/add-commit-push";
 import checkoutMaster from "../helpers/checkout-master";
 import getNewVersion from "../helpers/get-new-version";
 import isValidReleaseType from "../helpers/is-valid-release-type";
-import { PackageConfig, ReleaseTag } from "../types";
+import { PackageConfig, PreReleaseId, ReleaseTag } from "../types";
 
 export default function cutRelease(): void {
   const argv = yargs
@@ -18,6 +18,7 @@ export default function cutRelease(): void {
   const skipCheckout: boolean = argv.skipCheckout;
   const type: ReleaseType = argv.type;
   const tag: ReleaseTag | undefined = argv.tag;
+  const preReleaseId: PreReleaseId | undefined = argv.preid;
 
   if (!isValidReleaseType(type)) {
     shell.echo("cutoff expected type to be a valid release type.");
@@ -28,7 +29,7 @@ export default function cutRelease(): void {
   const configPath = resolve(process.cwd(), "package.json");
   const config: PackageConfig = require(configPath);
   const { scripts = {}, version } = config;
-  const newVersion = getNewVersion(version, type, tag);
+  const newVersion = getNewVersion(version, type, tag, preReleaseId);
   if (!newVersion) return;
 
   if (!skipCheckout) {

--- a/src/helpers/get-new-version/index.test.ts
+++ b/src/helpers/get-new-version/index.test.ts
@@ -29,12 +29,35 @@ describe("the getNewVersion function", () => {
   });
 
   describe("when a valid version is passed into the function", () => {
-    beforeAll(() => {
-      newVersion = getNewVersion("0.0.1", "patch");
+    describe("when ReleaseTag is not present", () => {
+      beforeAll(() => {
+        newVersion = getNewVersion("0.0.1", "patch");
+      });
+
+      it("then the function should return the new version", () => {
+        expect(newVersion).toBe("0.0.2");
+      });
     });
 
-    it("then the function should return the new version", () => {
-      expect(newVersion).toBe("0.0.2");
+    describe("when ReleaseTag is present", () => {
+      beforeAll(() => {
+        newVersion = getNewVersion("0.0.1", "prerelease", "alpha");
+      });
+
+      it("then the function should return the new version", () => {
+        expect(newVersion).toBe("0.0.2-alpha.0");
+      });
     });
+
+    describe("when ReleaseTag and PreReleaseId present", () => {
+      beforeAll(() => {
+        newVersion = getNewVersion("0.0.1", "prerelease", "unstable", "233");
+      });
+
+      it("then the function should return the new version", () => {
+        expect(newVersion).toBe("0.0.2-unstable233.0");
+      });
+    });
+
   });
 });

--- a/src/helpers/get-new-version/index.ts
+++ b/src/helpers/get-new-version/index.ts
@@ -8,6 +8,7 @@ export default function getNewVersion(
   tag?: ReleaseTag,
   preReleaseId?: PreReleaseId,
   ): string | undefined {
+
   if (tag && preReleaseId) {
     tag += preReleaseId;
   }

--- a/src/helpers/get-new-version/index.ts
+++ b/src/helpers/get-new-version/index.ts
@@ -6,10 +6,12 @@ export default function getNewVersion(
   version: string,
   type: ReleaseType,
   tag?: ReleaseTag,
-  preReleaseId?: PreReleaseId): string | undefined {
+  preReleaseId?: PreReleaseId,
+  ): string | undefined {
   if (tag && preReleaseId) {
     tag += preReleaseId;
   }
+
   const newVersion = semver.inc(version, type, false, tag);
 
   if (!newVersion) {

--- a/src/helpers/get-new-version/index.ts
+++ b/src/helpers/get-new-version/index.ts
@@ -1,8 +1,15 @@
 import semver, { ReleaseType } from "semver";
 import shell from "shelljs";
-import { ReleaseTag } from "../../types";
+import { PreReleaseId, ReleaseTag } from "../../types";
 
-export default function getNewVersion(version: string, type: ReleaseType, tag?: ReleaseTag): string | undefined {
+export default function getNewVersion(
+  version: string,
+  type: ReleaseType,
+  tag?: ReleaseTag,
+  preReleaseId?: PreReleaseId): string | undefined {
+  if (tag && preReleaseId) {
+    tag += preReleaseId;
+  }
   const newVersion = semver.inc(version, type, false, tag);
 
   if (!newVersion) {

--- a/src/helpers/get-new-version/index.ts
+++ b/src/helpers/get-new-version/index.ts
@@ -7,8 +7,7 @@ export default function getNewVersion(
   type: ReleaseType,
   tag?: ReleaseTag,
   preReleaseId?: PreReleaseId,
-  ): string | undefined {
-
+): string | undefined {
   if (tag && preReleaseId) {
     tag += preReleaseId;
   }

--- a/src/helpers/get-tag/index.test.ts
+++ b/src/helpers/get-tag/index.test.ts
@@ -1,0 +1,11 @@
+import getTag from ".";
+
+describe("the getTag function", () => {
+  it("should get release tag when no pre-release id", () => {
+    expect(getTag("1.2.3-unstable.0")).toBe("unstable");
+  });
+
+  it("should get release tag when a pre-release id is present", () => {
+    expect(getTag("1.2.3-unstable-233.0")).toBe("unstable-233");
+  });
+});

--- a/src/helpers/get-tag/index.test.ts
+++ b/src/helpers/get-tag/index.test.ts
@@ -6,6 +6,6 @@ describe("the getTag function", () => {
   });
 
   it("should get release tag when a pre-release id is present", () => {
-    expect(getTag("1.2.3-unstable-233.0")).toBe("unstable-233");
+    expect(getTag("1.2.3-unstable233.0")).toBe("unstable233");
   });
 });

--- a/src/helpers/get-tag/index.ts
+++ b/src/helpers/get-tag/index.ts
@@ -1,5 +1,8 @@
 export default function getTag(version: string): string | void {
-  if (/alfa/.test(version)) return "alfa";
+  if (/alpha/.test(version)) return "alpha";
   if (/beta/.test(version)) return "beta";
-  if (/unstable/.test(version)) return "unstable";
+
+  const matches = version.match(new RegExp("(unstable(.*))\\.\\d+"));
+
+  if (matches) return matches[1];
 }

--- a/src/helpers/is-valid-release-tag/index.ts
+++ b/src/helpers/is-valid-release-tag/index.ts
@@ -1,0 +1,7 @@
+import { ReleaseTag } from "../../types";
+
+const RELEASE_TAGS = ["alpha", "beta", "unstable"];
+
+export default function isValidReleaseTag(tag: ReleaseTag): boolean {
+  return RELEASE_TAGS.includes(tag);
+}

--- a/src/lerna/cut-release/index.test.ts
+++ b/src/lerna/cut-release/index.test.ts
@@ -64,7 +64,7 @@ describe("the cutLernaRelease function", () => {
     });
 
     it("then the function should call getNewVersion with the correct version and type", () => {
-      expect(getNewVersion).toHaveBeenCalledWith("0.0.1", "patch", undefined);
+      expect(getNewVersion).toHaveBeenCalledWith("0.0.1", "patch", undefined, undefined);
     });
 
     it("then the function should call checkoutMaster", () => {

--- a/src/lerna/cut-release/index.test.ts
+++ b/src/lerna/cut-release/index.test.ts
@@ -114,6 +114,22 @@ describe("the cutLernaRelease function", () => {
     });
   });
 
+  describe("when an invalid tag is passed into the function", () => {
+    beforeEach(() => {
+      (yargs.parse as jest.Mock).mockReturnValue({ type: "prerelease", tag: "invalid" });
+      cutLernaRelease();
+    });
+
+    it("then the function should echo the correct message", () => {
+      const message = "cutoff expected tag to be a valid release tag.";
+      expect(shell.echo).toBeCalledWith(message);
+    });
+
+    it("then the function should exit with the correct code", () => {
+      expect(shell.exit).toBeCalledWith(1);
+    });
+  });
+
   describe("when force is passed into the function", () => {
     beforeAll(() => {
       (yargs.parse as jest.Mock).mockReturnValue({ force: true, type: "patch" });

--- a/src/lerna/cut-release/index.test.ts
+++ b/src/lerna/cut-release/index.test.ts
@@ -56,6 +56,22 @@ describe("the cutLernaRelease function", () => {
     });
   });
 
+  describe("when an invalid tag is passed into the function", () => {
+    beforeAll(() => {
+      (yargs.parse as jest.Mock).mockReturnValue({ type: "prerelease", tag: "invalid" });
+      cutLernaRelease();
+    });
+
+    it("then the function should echo the correct message", () => {
+      const message = "cutoff expected tag to be a valid release tag.";
+      expect(shell.echo).toBeCalledWith(message);
+    });
+
+    it("then the function should exit with the correct code", () => {
+      expect(shell.exit).toBeCalledWith(1);
+    });
+  });
+
   describe("when a valid type is passed into the function", () => {
     beforeAll(() => {
       (yargs.parse as jest.Mock).mockReturnValue({ type: "patch" });

--- a/src/lerna/cut-release/index.ts
+++ b/src/lerna/cut-release/index.ts
@@ -6,9 +6,10 @@ import yargs from "yargs";
 import addCommitPush from "../../helpers/add-commit-push";
 import checkoutMaster from "../../helpers/checkout-master";
 import getNewVersion from "../../helpers/get-new-version";
+import isValidReleaseTag from "../../helpers/is-valid-release-tag";
 import isValidReleaseType from "../../helpers/is-valid-release-type";
 import forceUpdate from "../../lerna/helpers/force-update";
-import { LernaConfig, PackageConfig, ReleaseTag } from "../../types";
+import { LernaConfig, PackageConfig, PreReleaseId, ReleaseTag } from "../../types";
 import updatePackages from "../helpers/update-packages";
 
 export default function cutLernaRelease(): void {
@@ -23,6 +24,7 @@ export default function cutLernaRelease(): void {
   const skipCheckout: boolean = argv.skipCheckout;
   const tag: ReleaseTag | undefined = argv.tag;
   const type: ReleaseType = argv.type;
+  const preReleaseId: PreReleaseId = argv.preid;
 
   if (!isValidReleaseType(type)) {
     shell.echo("cutoff expected type to be a valid release type.");
@@ -30,10 +32,16 @@ export default function cutLernaRelease(): void {
     return;
   }
 
+  if (tag && !isValidReleaseTag(tag)) {
+    shell.echo("cutoff expected tag to be a valid release tag.");
+    shell.exit(1);
+    return;
+  }
+
   const configPath = resolve(process.cwd(), "package.json");
   const config: PackageConfig = require(configPath);
   const { scripts = {}, version } = config;
-  const newVersion = getNewVersion(version, type, tag);
+  const newVersion = getNewVersion(version, type, tag, preReleaseId);
   if (!newVersion) return;
 
   if (!skipCheckout) {

--- a/src/lerna/helpers/update-packages/index.ts
+++ b/src/lerna/helpers/update-packages/index.ts
@@ -2,7 +2,7 @@ import { readdirSync, statSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import semver, { ReleaseType } from "semver";
 import getNewVersion from "../../../helpers/get-new-version";
-import { ConfigMap, PackageConfig, ReleaseTag, StringObjectMap, UpdatedPackage } from "../../../types";
+import { ConfigMap, PackageConfig, PreReleaseId, ReleaseTag, StringObjectMap, UpdatedPackage } from "../../../types";
 
 function updateDependencies(
   updatedNames: string[],
@@ -26,7 +26,7 @@ function updateDependencies(
   return updated;
 }
 
-export default function updatePackages(type: ReleaseType, tag?: ReleaseTag): void {
+export default function updatePackages(type: ReleaseType, tag?: ReleaseTag, preReleaseId?: PreReleaseId): void {
   const cwd = process.cwd();
   const updatedConfigPath = resolve(cwd, ".lerna.updated.json");
   const updatedConfig: UpdatedPackage[] = require(updatedConfigPath) || [];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,7 +10,9 @@ export interface ObjectMap {
   [key: string]: any;
 }
 
-export type ReleaseTag = "alfa" | "beta" | "unstable";
+export type PreReleaseId = string;
+
+export type ReleaseTag = "alpha" | "beta" | "unstable";
 
 export interface PackageConfig {
   name: string;


### PR DESCRIPTION
Support for a pre release identifier to be appended to pre-release tags.
`1.2.3-unstable233.0`. 
Here `unstable`  is the pre-release tag and `233` is the pre-release-identifier.
However for semver the full `unstable233` is the `preid`