### PR TITLE
enhance(publish-lerna-cutoff): option to control concurrency

### DIFF
--- a/src/lerna/publish-release/index.test.ts
+++ b/src/lerna/publish-release/index.test.ts
@@ -3,6 +3,7 @@ import yargs from "yargs";
 import publishLernaRelease from ".";
 
 jest.mock("shelljs", () => ({ exec: jest.fn() }));
+
 jest.mock("yargs", () => ({
   number: jest.fn().mockReturnThis(),
   parse: jest.fn(),

--- a/src/lerna/publish-release/index.test.ts
+++ b/src/lerna/publish-release/index.test.ts
@@ -30,7 +30,7 @@ describe("the publishLernaRelease function", () => {
 
     it("then the function should execute the lerna exec command with the correct list of package names", () => {
       /* tslint:disable-next-line */
-      const cmd = "lerna exec --parallel --concurrency 3 -- publish-lerna-cutoff-pkg --packages @test/button @test/icon @test/link";
+      const cmd = "lerna exec --concurrency 3 -- publish-lerna-cutoff-pkg --packages @test/button @test/icon @test/link";
       expect(shell.exec).toHaveBeenCalledWith(cmd);
     });
   });

--- a/src/lerna/publish-release/index.test.ts
+++ b/src/lerna/publish-release/index.test.ts
@@ -1,7 +1,12 @@
 import shell from "shelljs";
+import yargs from "yargs";
 import publishLernaRelease from ".";
 
 jest.mock("shelljs", () => ({ exec: jest.fn() }));
+jest.mock("yargs", () => ({
+  number: jest.fn().mockReturnThis(),
+  parse: jest.fn(),
+}));
 
 describe("the publishLernaRelease function", () => {
   let processCwd: () => string;
@@ -10,6 +15,7 @@ describe("the publishLernaRelease function", () => {
   beforeAll(() => {
     processCwd = process.cwd;
     process.cwd = jest.fn().mockReturnValue(REPO_PATH);
+    (yargs.parse as jest.Mock).mockReturnValue({ concurrency: 3 });
   });
 
   afterAll(() => {
@@ -22,7 +28,8 @@ describe("the publishLernaRelease function", () => {
     });
 
     it("then the function should execute the lerna exec command with the correct list of package names", () => {
-      const cmd = "lerna exec --parallel -- publish-lerna-cutoff-pkg --packages @test/button @test/icon @test/link";
+      /* tslint:disable-next-line */
+      const cmd = "lerna exec --parallel --concurrency 3 -- publish-lerna-cutoff-pkg --packages @test/button @test/icon @test/link";
       expect(shell.exec).toHaveBeenCalledWith(cmd);
     });
   });

--- a/src/lerna/publish-release/index.ts
+++ b/src/lerna/publish-release/index.ts
@@ -8,6 +8,5 @@ export default function publishLernaRelease(): void {
   const updated: UpdatedPackage[] = require(updatedConfigPath) || [];
   const names = updated.map((pkg) => pkg.name);
   const concurrency: number = yargs.number("concurrency").parse().concurrency || 4;
-  /* tslint:disable-next-line */
-  shell.exec(`lerna exec --parallel --concurrency ${concurrency} -- publish-lerna-cutoff-pkg --packages ${names.join(" ")}`);
+  shell.exec(`lerna exec --concurrency ${concurrency} -- publish-lerna-cutoff-pkg --packages ${names.join(" ")}`);
 }

--- a/src/lerna/publish-release/index.ts
+++ b/src/lerna/publish-release/index.ts
@@ -1,10 +1,13 @@
 import { resolve } from "path";
 import shell from "shelljs";
+import yargs from "yargs";
 import { UpdatedPackage } from "../../types";
 
 export default function publishLernaRelease(): void {
   const updatedConfigPath = resolve(process.cwd(), ".lerna.updated.json");
   const updated: UpdatedPackage[] = require(updatedConfigPath) || [];
   const names = updated.map((pkg) => pkg.name);
-  shell.exec(`lerna exec --parallel -- publish-lerna-cutoff-pkg --packages ${names.join(" ")}`);
+  const concurrency: number = yargs.number("concurrency").parse().concurrency || 4;
+  /* tslint:disable-next-line */
+  shell.exec(`lerna exec --parallel --concurrency ${concurrency} -- publish-lerna-cutoff-pkg --packages ${names.join(" ")}`);
 }


### PR DESCRIPTION
`lerna --parallel` execute immediately. provide optional `-concurrency` control to safe guard system limits.